### PR TITLE
Add different xdebug config for macos/windows and linux

### DIFF
--- a/root/entrypoint.sh
+++ b/root/entrypoint.sh
@@ -8,6 +8,7 @@ then
     inifile="/usr/local/etc/php/conf.d/pecl-xdebug.ini"
     extfile="$(find /usr/local/lib/php/extensions/ -name xdebug.so)";
     remote_port="${XDEBUG_REMOTE_PORT:-9000}";
+    remote_os="${XDEBUG_REMOTE_OS:-linux}";
     idekey="${XDEBUG_IDEKEY:-xdbg}";
 
     if [ -f "$extfile" ] && [ ! -f "$inifile" ];
@@ -17,10 +18,22 @@ then
             echo "zend_extension=${extfile}";
             echo "xdebug.idekey=${idekey}";
             echo "xdebug.remote_enable=1";
-            echo "xdebug.remote_connect_back=1";
             echo "xdebug.remote_autostart=1";
             echo "xdebug.remote_port=${remote_port}";
         } > $inifile;
+
+        if [ $remote_os = "macos" ] || [ $remote_os = "windows"];
+        then
+            {
+                echo "xdebug.remote_connect_back=0";
+                echo "xdebug.remote_host=host.docker.internal";
+            } >> $inifile;
+        else
+            {
+                echo "xdebug.remote_connect_back=1";
+            } >> $inifile;
+        fi
+
     fi
 
     unset extfile remote_port idekey;


### PR DESCRIPTION
Fabio!

Here's a PR that should add the possibility to get Xdebug to run under macOS and Windows. I haven't tested it because the tiki-docker compose yaml files reference the tikiwiki image that references the php image, so it's a mess for me to test. But that should be straightforward. Let me know if it's fine or if I need to change anything. Also you should be able to merge this in the other branches, right? Could you do it?

There's another point that we need to discuss about: once you've clone tiki-docker and starting your docker environments, how will be people update the tiwiki/php images?